### PR TITLE
change deserialize support type with dash

### DIFF
--- a/Serializer/Handler/JsonApiResourceHandler.php
+++ b/Serializer/Handler/JsonApiResourceHandler.php
@@ -56,7 +56,8 @@ class JsonApiResourceHandler implements SubscribingHandlerInterface
         Context $context
     )
     {
-        $resourceName = $data['type'];
+        $resourceName = str_replace('-', '_', $data['type']);
+
         $classMetadata = $this->jsonapiMetadataFactory->getMetadataForResource($resourceName);
 
         if (null === $classMetadata) {


### PR DESCRIPTION
account endpoint post saved-listings has dash in the type, and original code did not support.