### PR TITLE
Upgrade php

### DIFF
--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -11,6 +11,7 @@
 
 namespace Mango\Bundle\JsonApiBundle\Serializer;
 
+use JMS\Serializer\Accessor\AccessorStrategyInterface;
 use JMS\Serializer\Context;
 use JMS\Serializer\JsonSerializationVisitor;
 use JMS\Serializer\Metadata\ClassMetadata;
@@ -47,18 +48,21 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
     private $includeTypes = [];
 
     /**
+     * JsonApiSerializationVisitor constructor.
      * @param PropertyNamingStrategyInterface $propertyNamingStrategy
+     * @param AccessorStrategyInterface $accessorStrategy
      * @param MetadataFactoryInterface $metadataFactory
-     * @param bool $showVersionInfo
-     * @param integer $includeMaxDepth
+     * @param $showVersionInfo
+     * @param null $includeMaxDepth
      */
     public function __construct(
         PropertyNamingStrategyInterface $propertyNamingStrategy,
+        AccessorStrategyInterface $accessorStrategy,
         MetadataFactoryInterface $metadataFactory,
         $showVersionInfo,
         $includeMaxDepth = null
     ) {
-        parent::__construct($propertyNamingStrategy);
+        parent::__construct($propertyNamingStrategy, $accessorStrategy);
 
         $this->metadataFactory = $metadataFactory;
         $this->showVersionInfo = $showVersionInfo;

--- a/Serializer/JsonApiSerializationVisitor.php
+++ b/Serializer/JsonApiSerializationVisitor.php
@@ -52,8 +52,8 @@ class JsonApiSerializationVisitor extends JsonSerializationVisitor
      * @param PropertyNamingStrategyInterface $propertyNamingStrategy
      * @param AccessorStrategyInterface $accessorStrategy
      * @param MetadataFactoryInterface $metadataFactory
-     * @param $showVersionInfo
-     * @param null $includeMaxDepth
+     * @param bool $showVersionInfo
+     * @param int $includeMaxDepth
      */
     public function __construct(
         PropertyNamingStrategyInterface $propertyNamingStrategy,

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|~7.0",
+        "php": "~7.2",
         "symfony/framework-bundle": "~2.3|~3.0",
         "jms/serializer-bundle": "~0.13|~1.0",
         "pagerfanta/pagerfanta": "~1.0",


### PR DESCRIPTION
For PHP 7.2 there's a package update required for `jms/serializer` and [in 1.6 the constructor signature changed](https://github.com/schmittjoh/serializer/commit/4e0c009e9c27ab765fe243a4f96d85744ca754c4#diff-6ab10c291ef58c383711617e89df679bR34). 
We need to tag this change before we can update datalayer packages in UAT.