### PR TITLE
Composer update

### DIFF
--- a/bin/phpspec
+++ b/bin/phpspec
@@ -1,0 +1,1 @@
+../vendor/phpspec/phpspec/bin/phpspec

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~7.2",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "jms/serializer-bundle": "^2.0|^3.0",
+        "jms/serializer-bundle": "~2.0|~3.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~7.2",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-        "jms/serializer-bundle": "~2.0",
+        "jms/serializer-bundle": "~1.0|~2.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~7.2",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "jms/serializer-bundle": "^2.0",
+        "jms/serializer-bundle": "^2.0|^3.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "~7.2",
-        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+        "symfony/framework-bundle": "~2.3|~3.0",
         "jms/serializer-bundle": "~1.0|~2.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "~7.2",
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "jms/serializer-bundle": "~2.0|~3.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~7.2",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-        "jms/serializer-bundle": "~2.0|~3.0",
+        "jms/serializer-bundle": "~2.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "~7.2",
         "symfony/framework-bundle": "~2.3|~3.0",
-        "jms/serializer-bundle": "~0.13|~1.0",
+        "jms/serializer-bundle": "^2.0",
         "pagerfanta/pagerfanta": "~1.0",
         "willdurand/hateoas": ">2.0"
     },


### PR DESCRIPTION
### Issue
Currently, the `jms/serializer-bundle` 1.x supports only upto symfony 3. 

### Solution
Update the 2 packages to support later versions of symfony