### PR TITLE
MI-1449: Fix depth deprecation

### DIFF
--- a/Serializer/Serializer.php
+++ b/Serializer/Serializer.php
@@ -102,7 +102,7 @@ class Serializer implements FosRestSerializerInterface
         if (!empty($groups)) {
             $jmsContext->setGroups($context->getGroups());
         }
-        if (null !== $context->getMaxDepth()) {
+        if (null !== $context->isMaxDepthEnabled()) {
             $jmsContext->enableMaxDepthChecks();
         }
         if (null !== $context->getSerializeNull()) {


### PR DESCRIPTION
## Issue
The `getMaxDepth()` method has been deprecated from v3.x

## Solution
Update to use new method
https://github.com/FriendsOfSymfony/FOSRestBundle/blob/2.x/Context/Context.php#L150